### PR TITLE
解决批次内全量拉取binlog更新量导致socket异常问题

### DIFF
--- a/src/main/java/org/apache/spark/sql/mlsql/sources/MLSQLBinLogDataSource.scala
+++ b/src/main/java/org/apache/spark/sql/mlsql/sources/MLSQLBinLogDataSource.scala
@@ -366,7 +366,7 @@ case class MLSQLBinLogSource(executorBinlogServer: ExecutorBinlogServer,
     // todo: optimize the way to fetch data
     val rdd = spark.sparkContext.parallelize(Seq("fetch-bing-log"), 1).mapPartitions { iter =>
       val consumer = ExecutorBinlogServerConsumerCache.acquire(executorBinlogServerCopy)
-      consumer.fetchData(fromPartitionOffsets.get, untilPartitionOffsets.get).toIterator
+      consumer.fetchData(fromPartitionOffsets.get, untilPartitionOffsets.get)
     }.map { cr =>
       InternalRow(UTF8String.fromString(cr))
     }
@@ -403,8 +403,10 @@ case class ExecutorInternalBinlogConsumer(executorBinlogServer: ExecutorBinlogSe
         start.offset,
         end.offset))
       // todo: optimize the way to fetch data
-      val response = readResponse(dIn)
-      response.asInstanceOf[DataResponse].data
+      //      val response = readResponse(dIn)
+      val response = readIteratedResponse(dIn)
+      //      response.asInstanceOf[DataResponse].data
+      response.flatMap(f=>f.asInstanceOf[DataResponse].data)
     } finally {
       ExecutorBinlogServerConsumerCache.release(this)
     }

--- a/src/main/java/org/apache/spark/sql/mlsql/sources/mysql/binlog/protocols.scala
+++ b/src/main/java/org/apache/spark/sql/mlsql/sources/mysql/binlog/protocols.scala
@@ -124,3 +124,9 @@ case class BinlogSocketRequest(
     }
   }
 }
+
+object SocketReplyMark {
+  val HEAD = -2 // 交付开始
+  val END = -1 // 交付结束
+}
+


### PR DESCRIPTION
修改socket传输协议为[head length data end]增加启止位持续交付，而不是全量放入内存，并将socket数据封装成Iterator返回